### PR TITLE
Fix context providers

### DIFF
--- a/src/context/font-context.tsx
+++ b/src/context/font-context.tsx
@@ -35,7 +35,11 @@ export const FontProvider: React.FC<{ children: React.ReactNode }> = ({
     _setFont(font)
   }
 
-  return <FontContext value={{ font, setFont }}>{children}</FontContext>
+  return (
+    <FontContext.Provider value={{ font, setFont }}>
+      {children}
+    </FontContext.Provider>
+  )
 }
 
 // eslint-disable-next-line react-refresh/only-export-components

--- a/src/features/tasks/context/tasks-context.tsx
+++ b/src/features/tasks/context/tasks-context.tsx
@@ -21,9 +21,9 @@ export default function TasksProvider({ children }: Props) {
   const [open, setOpen] = useDialogState<TasksDialogType>(null)
   const [currentRow, setCurrentRow] = useState<Task | null>(null)
   return (
-    <TasksContext value={{ open, setOpen, currentRow, setCurrentRow }}>
+    <TasksContext.Provider value={{ open, setOpen, currentRow, setCurrentRow }}>
       {children}
-    </TasksContext>
+    </TasksContext.Provider>
   )
 }
 

--- a/src/features/users/context/users-context.tsx
+++ b/src/features/users/context/users-context.tsx
@@ -22,9 +22,9 @@ export default function UsersProvider({ children }: Props) {
   const [currentRow, setCurrentRow] = useState<User | null>(null)
 
   return (
-    <UsersContext value={{ open, setOpen, currentRow, setCurrentRow }}>
+    <UsersContext.Provider value={{ open, setOpen, currentRow, setCurrentRow }}>
       {children}
-    </UsersContext>
+    </UsersContext.Provider>
   )
 }
 


### PR DESCRIPTION
## Summary
- fix context providers to correctly use `.Provider`

## Testing
- `pnpm run lint` *(fails: Cannot find package 'globals')*
- `pnpm run build` *(fails: missing modules)*
- `pnpm run format:check` *(fails: Cannot find package '@trivago/prettier-plugin-sort-imports')*